### PR TITLE
Extract shared escapeRegex into src/helpers/utils.ts

### DIFF
--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,0 +1,7 @@
+/**
+ * Escapes special regex characters in a string so it can be used
+ * as a literal pattern in a RegExp constructor.
+ */
+export function escapeRegex(str: string): string {
+	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import {
 	findWpCli,
 } from './helpers/paths';
 import { SiteConfig, SiteConfigRegistry } from './helpers/site-config';
+import { escapeRegex } from './helpers/utils';
 import { findAvailablePort, savePort, removePortFile } from './helpers/port';
 import { createMcpHttpServer, startMcpHttpServer, stopMcpHttpServer, closeSessionsForSite } from './mcp-server';
 import { LocalApi } from './tools';
@@ -121,10 +122,6 @@ function getStoredAgents(site: Local.Site): AgentTarget[] {
 
 function isAgentToolsEnabled(site: Local.Site): boolean {
 	return !!site.customOptions?.agentToolsEnabled;
-}
-
-function escapeRegex(str: string): string {
-	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 // ---------------------------------------------------------------------------

--- a/src/tools/config.ts
+++ b/src/tools/config.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile, copyFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import * as path from 'path';
 import { SiteConfig } from '../helpers/site-config';
+import { escapeRegex } from '../helpers/utils';
 
 // ── Tool Definitions ───────────────────────────────────────────────────
 export const toolDefinitions = [
@@ -199,6 +200,3 @@ function parseDefineConstants(content: string): Record<string, string> {
 	return constants;
 }
 
-function escapeRegex(str: string): string {
-	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}


### PR DESCRIPTION
## Summary

- Created `src/helpers/utils.ts` with a shared `escapeRegex()` function
- Replaced the duplicate local `escapeRegex()` in `src/main.ts` with an import from the new utility module
- Replaced the duplicate local `escapeRegex()` in `src/tools/config.ts` with an import from the new utility module

## Acceptance Criteria

- `escapeRegex` is defined once in `src/helpers/utils.ts` and exported
- `src/main.ts` imports from the shared module instead of defining its own copy
- `src/tools/config.ts` imports from the shared module instead of defining its own copy
- TypeScript compiles without errors
- No duplicate `escapeRegex` definitions remain in the codebase

Closes #30
