### PR TITLE
Add .github/CODEOWNERS for auto-assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for everything in the repo.
+# Ensures all PRs (including Dependabot) get a reviewer auto-assigned.
+* @christianc1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LocalWP Agent Tools
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![CI](https://github.com/10up/localwp-agent-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/10up/localwp-agent-tools/actions/workflows/ci.yml) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/localwp-agent-tools.svg)](https://github.com/10up/localwp-agent-tools/blob/main/LICENSE.md) 
+[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![CI](https://github.com/10up/localwp-agent-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/10up/localwp-agent-tools/actions/workflows/ci.yml) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/localwp-agent-tools.svg)](https://github.com/10up/localwp-agent-tools/blob/main/LICENSE.md)
 
 > A [Local](https://localwp.com/) add-on that provides an MCP server and project context for AI-powered WordPress development. Works with Claude Code, Cursor, Windsurf, VS Code Copilot, and any MCP client.
 


### PR DESCRIPTION
## Summary

Adds a `.github/CODEOWNERS` file with `@christianc1` as the default owner for the entire repo, so PRs (including Dependabot) get a reviewer auto-assigned.

```
* @christianc1
```

Closes #59.

## Test plan

- [ ] After merge, confirm the next Dependabot PR auto-requests review from `@christianc1`.
- [ ] Open a manual test PR and confirm the same.