### PR TITLE
Don't auto-skip plugins/themes in wp_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LocalWP Agent Tools
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![CI](https://github.com/10up/localwp-agent-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/10up/localwp-agent-tools/actions/workflows/ci.yml) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/localwp-agent-tools.svg)](https://github.com/10up/localwp-agent-tools/blob/main/LICENSE.md) 
+[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) [![CI](https://github.com/10up/localwp-agent-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/10up/localwp-agent-tools/actions/workflows/ci.yml) [![GPL-2.0-or-later License](https://img.shields.io/github/license/10up/localwp-agent-tools.svg)](https://github.com/10up/localwp-agent-tools/blob/main/LICENSE.md)
 
 > A [Local](https://localwp.com/) add-on that provides an MCP server and project context for AI-powered WordPress development. Works with Claude Code, Cursor, Windsurf, VS Code Copilot, and any MCP client.
 

--- a/src/tools/wpcli.ts
+++ b/src/tools/wpcli.ts
@@ -63,9 +63,6 @@ async function runWpCli(
 		cmdArgs.push(`--path=${config.wpPath}`);
 	}
 
-	// Skip themes/plugins that may fatally error
-	cmdArgs.push('--skip-themes', '--skip-plugins');
-
 	const timeout = options?.timeout ?? 60_000;
 
 	const env = buildWpCliEnv(config);
@@ -84,6 +81,7 @@ export const toolDefinitions = [
 		name: 'wp_cli',
 		description:
 			'Run an arbitrary WP-CLI command. Pass arguments without the leading "wp" prefix. Example: args="post list --post_type=page --format=json"\n\n' +
+			'Plugins and themes are loaded by default so plugin-provided commands (e.g. "elasticpress stats", "acf", "redis") work. If a specific plugin or theme is fatally erroring, pass "--skip-plugins=<slug>" / "--skip-themes=<slug>" (or the bare flags to skip all) to bypass it.\n\n' +
 			'WARNING: Some WP-CLI commands are destructive and should only be run after confirming with the user:\n' +
 			'- "eval" / "eval-file" / "shell" — execute arbitrary PHP code\n' +
 			'- "db drop" / "db reset" — destroy the database\n' +

--- a/tests/tools/__snapshots__/definitions.test.ts.snap
+++ b/tests/tools/__snapshots__/definitions.test.ts.snap
@@ -184,6 +184,8 @@ exports[`Tool definitions snapshot > tool descriptions match snapshot 1`] = `
   {
     "description": "Run an arbitrary WP-CLI command. Pass arguments without the leading "wp" prefix. Example: args="post list --post_type=page --format=json"
 
+Plugins and themes are loaded by default so plugin-provided commands (e.g. "elasticpress stats", "acf", "redis") work. If a specific plugin or theme is fatally erroring, pass "--skip-plugins=<slug>" / "--skip-themes=<slug>" (or the bare flags to skip all) to bypass it.
+
 WARNING: Some WP-CLI commands are destructive and should only be run after confirming with the user:
 - "eval" / "eval-file" / "shell" — execute arbitrary PHP code
 - "db drop" / "db reset" — destroy the database


### PR DESCRIPTION
## Summary

`runWpCli` was always appending `--skip-themes --skip-plugins`, which made plugin-provided WP-CLI commands (e.g. `wp elasticpress stats`, `wp acf`, `wp redis`) unreachable through the MCP tool — Claude would see "command not found" instead of being able to use the plugin's CLI.

This drops the unconditional flags. Plugins and themes load by default; if a specific plugin/theme fatals, the caller passes `--skip-plugins=<slug>` (or the bare flag) per command. The tool description now documents this so the agent can self-recover from a plugin fatal without dropping out to a terminal.

- `src/tools/wpcli.ts` — remove the auto-injected `--skip-themes --skip-plugins`; expand the tool description to call out the new default and the per-command escape hatch.
- `tests/tools/__snapshots__/definitions.test.ts.snap` — regenerate to match the updated description.

Closes #58

## Test plan

- [x] `npm run lint` (no new errors; pre-existing warnings only)
- [x] `npx tsc --noEmit`
- [x] `npm run test:coverage` — 102/102 pass
- [x] `npm run build`
- [ ] Against a Local site with ElasticPress: `wp_cli` with `args: "elasticpress stats"` returns plugin output instead of "command not found"
- [ ] `wp_cli` with `args: "plugin list --format=json"` still works
- [ ] `wp_cli` with `args: "--skip-plugins=problematic-plugin plugin list"` — caller-provided skip flag is preserved